### PR TITLE
Add env vars to set a single default address pool

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,15 @@ create-array() {
     fi
 }
 
+create-default-address-pool() {
+    local pool_base=$1
+    local pool_size=$2
+
+    if [ -n "${pool_base}" ] && [ -n "${pool_size}" ]; then
+        jq -n "{\"default-address-pools\": [{\"base\": \"${pool_base}\", \"size\": ${pool_size}}]}"
+    fi
+}
+
 debug=$(create-attribute "debug" "${DEBUG}")
 hosts=$(create-array "hosts" "${HOSTS}")
 registry_mirrors=$(create-array "registry-mirrors" "${REGISTRY_MIRRORS}")
@@ -37,8 +46,9 @@ dns=$(create-array "dns" "${DNS}")
 dns_opts=$(create-array "dns-opts" "${DNS_OPTS}")
 dns_search=$(create-array "dns-search" "${DNS_SEARCH}")
 labels=$(create-array "labels" "${LABELS}")
+default_pool=$(create-default-address-pool ${POOL_BASE} ${POOL_SIZE})
 
-echo "${debug} ${hosts} ${registry_mirrors} ${insecure_registries} ${dns} ${dns_opts} ${dns_search} ${labels}" \
+echo "${debug} ${hosts} ${registry_mirrors} ${insecure_registries} ${dns} ${dns_opts} ${dns_search} ${labels} ${default_pool}" \
 | jq -s add > ${HOME}/.config/docker/daemon.json
 
 exec ${HOME}/bin/dockerd-rootless.sh --config-file ${HOME}/.config/docker/daemon.json


### PR DESCRIPTION
The POOL_BASE and POOL_SIZE can be used to set an alternative default address pool. This can be used to eliminate overlap conflicts