### PR TITLE
entrypoint.sh now adds to an existing daemon.json

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,10 @@ create-default-address-pool() {
     fi
 }
 
+existing_config="{}"
+if [ -f ${HOME}/.config/docker/daemon.json ]; then
+    existing_config=$(cat ${HOME}/.config/docker/daemon.json)
+fi
 debug=$(create-attribute "debug" "${DEBUG}")
 hosts=$(create-array "hosts" "${HOSTS}")
 registry_mirrors=$(create-array "registry-mirrors" "${REGISTRY_MIRRORS}")
@@ -48,7 +52,7 @@ dns_search=$(create-array "dns-search" "${DNS_SEARCH}")
 labels=$(create-array "labels" "${LABELS}")
 default_pool=$(create-default-address-pool ${POOL_BASE} ${POOL_SIZE})
 
-echo "${debug} ${hosts} ${registry_mirrors} ${insecure_registries} ${dns} ${dns_opts} ${dns_search} ${labels} ${default_pool}" \
+echo "${existing_config} ${debug} ${hosts} ${registry_mirrors} ${insecure_registries} ${dns} ${dns_opts} ${dns_search} ${labels} ${default_pool}" \
 | jq -s add > ${HOME}/.config/docker/daemon.json
 
 exec ${HOME}/bin/dockerd-rootless.sh --config-file ${HOME}/.config/docker/daemon.json


### PR DESCRIPTION
Previously the daemon.jsonm was created new based on env vars supplied at runtime. However, it can be handy for other child images to include their own daemon.json entries that aren't yet supported by the env vars. For example the nvidia container toolkit might be included in a child image and would need to add the runtime to daemon.json.

Now the entrypoint will append to any existing daemon.json