### PR TITLE
Implements graceful shutdown for docker stop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update -y \
         sudo \
         uidmap \
         fuse-overlayfs \
+        procps \
         --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
If dind has running containers and the XDG_RUNTIME_DIR is bind mounted to the host when a `docker stop` is issued then dind will exit without cleaning up pids, etc.

When any container is running then the containerd-shim is direct child of PID 1. This means that it directly gets the SIGTERM signal and will exiting without cleaning up. If there are no containers running then containerd-shim isn't running either.

In order to deal with this issue gracefully SIGTERM is trapped by the entrypoint and SIGHUP, SIGINT, and SIGTERM are progressively sent to any running containers in order to speed shutdown. Then dockerd and containerd are terminated and monitored until they fully exit.