### PR TITLE
Cleanup and document

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV HOME=/home/rootless
 ENV PATH="${PATH}:${HOME}/.local/bin:${HOME}/bin"
 ENV DOCKER_HOST="unix:///run/user/${ROOTLESS_UID}/docker.sock"
 ENV XDG_RUNTIME_DIR="/run/user/${ROOTLESS_UID}"
+ENV XDG_CONFIG_HOME="${HOME}/.config"
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,4 @@ RUN export SKIP_IPTABLES=1 \
 
 VOLUME /var/lib/docker
 VOLUME /home/rootless/.local/share/docker
-ENTRYPOINT ["/bin/bash", "-c"]
-CMD ["entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
-# debian-dind-rootless
+# Debian based Rootless Docker-in-Docker
+
+![Build and Push Image](https://github.com/enclarify/debian-dind-rootless/actions/workflows/build_push_image.yml/badge.svg)
+
+## Summary
+
+A Docker image similar to https://hub.docker.com/\_/docker but based on Debian and Rootless Docker only. The image at https://hub.docker.com/\_/docker is based on Alpine Linux which makes using some Docker extensions like the `nvidia-container-toolkit` impossible since it relies on glibc.
+
+## Configuration
+
+All configuration as described on https://hub.docker.com/\_/docker for the rootless tags are supported by this project.
+
+## Usage example
+
+All the usage examples related to rootless at https://hub.docker.com/\_/docker should work the same with this project. The simplest way to start the rootless container is:
+
+```bash
+docker run --name rootless-docker --privileged -d \
+enclarify/debian-dind-rootless:11.8-slim-<debian-dind-rootless version>
+```
+The rootless container can be tested by `docker exec rootless-docker docker info --format "{{.SecurityOptions}}"`. The output should show `[name=seccomp,profile=builtin name=rootless name=cgroupns]`. 
+
+A more practical example adds volumes to persist docker state, such as container images, and mounts the rootless docker socket back to the host. In order to write the docker socket with the correct permissions the `ROOTLESS_UID` environment variable is required to supply the UID of the current host user. The default value of `ROOTLESS_UID` is `1000` which should be the default for most users of a Linux host. 
+
+```bash
+docker run --name rootless-docker --privileged -d \
+-e ROOTLESS_UID=$(id -u) \
+--mount type=volume,src=rootless-storage,dst=/var/lib/docker \
+--mount type=volume,src=rootless-user-storage,dst=/home/rootless/.local/share/docker \
+--mount type=bind,src=${XDG_RUNTIME_DIR},dst=${XDG_RUNTIME_DIR} \
+enclarify/debian-dind-rootless:11.8-slim-<debian-dind-rootless version>
+```
+
+The rootless container can be tested by `docker -H unix://${XDG_RUNTIME_DIR}/docker.sock info --format "{{.SecurityOptions}}"`. The output should show `[name=seccomp,profile=builtin name=rootless name=cgroupns]`
+
+[!WARNING]
+It shoud be noted that if the rootless docker is bind mounted to the host then it must be gracefully stopped with `docker stop rootless-docker`. Otherwise stale socket and pid files will be left on disk which will prevent the rootless container from starting again until they are manually removed from `XDG_RUNTIME_DIR`. Usuually `XDG_RUNTIME_DIR` is located at `/var/run/user/1000`. In the case of an unclean shutdown the files that need to be removed manually are:
+
+```
+drwxr-xr-x  2 user1  group1  200 Mar 16 07:51 dockerd-rootless
+-rw-r--r-T  1 user1  group1    2 Mar 16 07:51 docker.pid
+srw-rw---T  1 user1  group1    0 Mar 16 07:51 docker.sock
+```
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,60 +39,7 @@ cleanup() {
 
 trap cleanup SIGTERM
 
-create-attribute() {
-    local key=$1
-    local value=$2
-
-    if [ -n "${value}" ]; then
-        jq -n "{ \"${key}\": ${value}}"
-    fi
-}
-
-create-string-attribute() {
-    local key=$1
-    local value=$2
-
-    if [ -n "${value}" ]; then
-        create-attribute "${key}" "\"${value}\""
-    fi
-}
-
-create-array() {
-    local key=$1
-    local value=$2
-
-    if [ -n "${value}" ]; then
-        jq -n "{ \"${key}\": \"${value}\" | split(\",\") }"
-    fi
-}
-
-create-default-address-pool() {
-    local pool_base=$1
-    local pool_size=$2
-
-    if [ -n "${pool_base}" ] && [ -n "${pool_size}" ]; then
-        jq -n "{\"default-address-pools\": [{\"base\": \"${pool_base}\", \"size\": ${pool_size}}]}"
-    fi
-}
-
-existing_config="{}"
-if [ -f ${HOME}/.config/docker/daemon.json ]; then
-    existing_config=$(cat ${HOME}/.config/docker/daemon.json)
-fi
-debug=$(create-attribute "debug" "${DEBUG}")
-hosts=$(create-array "hosts" "${HOSTS}")
-registry_mirrors=$(create-array "registry-mirrors" "${REGISTRY_MIRRORS}")
-insecure_registries=$(create-array "insecure-registries" "${INSECURE_REGISTRIES}")
-dns=$(create-array "dns" "${DNS}")
-dns_opts=$(create-array "dns-opts" "${DNS_OPTS}")
-dns_search=$(create-array "dns-search" "${DNS_SEARCH}")
-labels=$(create-array "labels" "${LABELS}")
-default_pool=$(create-default-address-pool ${POOL_BASE} ${POOL_SIZE})
-
-echo "${existing_config} ${debug} ${hosts} ${registry_mirrors} ${insecure_registries} ${dns} ${dns_opts} ${dns_search} ${labels} ${default_pool}" \
-| jq -s add > ${HOME}/.config/docker/daemon.json
-
-${HOME}/bin/dockerd-rootless.sh --config-file ${HOME}/.config/docker/daemon.json &
+${HOME}/bin/dockerd-rootless.sh "$@" &
 
 ROOTLESS_PID=$!
 wait "${ROOTLESS_PID}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,14 +15,17 @@ wait-for-proc-stop() {
 cleanup() {
     echo "Stopping any running containers"
     local container_pids=$(docker ps -aq -f "status=running")
-    echo "Sending SIGHUP to shutdown any containers running a shell like bash"
-    docker stop -s SIGHUP ${container_pids}
-    echo "Sending SIGINT to any running containers"
-    docker stop -s SIGINT ${container_pids}
-    echo "Sending SIGTERM to any running containers"
-    docker stop -s SIGTERM ${container_pids}
-    echo "Waiting for containers to stop"
-    docker wait ${container_pids}
+
+    if [ -n "${container_pids}" ]; then
+        echo "Sending SIGHUP to shutdown any containers running a shell like bash"
+        docker stop -s SIGHUP ${container_pids}
+        echo "Sending SIGINT to any running containers"
+        docker stop -s SIGINT ${container_pids}
+        echo "Sending SIGTERM to any running containers"
+        docker stop -s SIGTERM ${container_pids}
+        echo "Waiting for containers to stop"
+        docker wait ${container_pids}
+    fi
 
     local containerd_pid=$(pgrep containerd)
     local dockerd_pid=$(pgrep dockerd)


### PR DESCRIPTION
[Add XDG_CONFIG_HOME, rootless path of daemon.json](https://github.com/enclarify/debian-dind-rootless/commit/6319827619c68438ff58689cb8c61af7fae47287) 

The XDG_CONFIG_HOME environment variable is set to force daemon.json to
be read from the user home .config
[Fix graceful shutdown when no containers run](https://github.com/enclarify/debian-dind-rootless/commit/1bd33e50d9fa0cd96fcb190898c840576fbbf5ab) 

Where there are no existing running containers the container_pids will
be empty which will cause an error preventing the graceful shutdown from
working correctly.
[Change entrypoint to accept dockerd options](https://github.com/enclarify/debian-dind-rootless/commit/f32d928f00cf39aa419c7e220361d3dae5ea17da) 

Previously some of the options to dockerd were extracted from env vars
but allowing the command of the container to supply dockerd options
makes the entrypoint simpler and more robust
[Add README with overview and examples](https://github.com/enclarify/debian-dind-rootless/commit/eb1bb3f943c90fc35b9f414a12f15139d8a332e4)