### PR TITLE
Force listening at /var/run/docker.sock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,15 @@ RUN --mount=type=bind,source=setup-rootless-users.sh,target=/usr/bin/setup-rootl
     setup-rootless-users.sh
 
 COPY entrypoint.sh /usr/bin/
-RUN chmod +x /usr/bin/entrypoint.sh
+RUN chmod +x /usr/bin/entrypoint.sh \
+    && chown rootless:rootless /run
 
 # rootlesskit needs to be installed by the rootless user
 USER rootless
 RUN export SKIP_IPTABLES=1 \
     && curl -fsSL https://get.docker.com/rootless | sh \
+    && echo "Removing the '--copy-up=/run' from the dockerd-rootless.sh to allow /run/docker.sock" \
+    && sed -i 's| --copy-up=/run||g' /home/rootless/bin/dockerd-rootless.sh \
     && /home/rootless/bin/docker -v
 
 VOLUME /var/lib/docker

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,7 @@ cleanup() {
 
 trap cleanup SIGTERM
 
-${HOME}/bin/dockerd-rootless.sh "$@" &
+${HOME}/bin/dockerd-rootless.sh -H unix://${XDG_RUNTIME_DIR}/docker.sock -H unix:///run/docker.sock "$@" &
 
 ROOTLESS_PID=$!
 wait "${ROOTLESS_PID}"


### PR DESCRIPTION
Most systems expect the docker daemon to be listening at a file socket /var/run/docker.sock. However, since this is rootless it typically only listens at $XDG_RUNTIME_DIR/docker.sock. Besides the obvious changes of letting rootless write to /run and telling dockerd to listen at both file sockets with the -H option, the dockerd-rootless.sh startup script needed to be edited to not --copy-up=/run. The --copy-up option makes the location read-only from that point on (no warning is given even with debug tuned on).

Hacking the dockerd-rootless.sh script to remove the --copy-up=/run has the intended effect.