### PR TITLE
Fix rootless install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,9 @@ RUN apt-get update -y \
         curl \
         ca-certificates \
         iproute2 \
-        iptables \
         jq \
         sudo \
         uidmap \
-        fuse-overlayfs \
         procps \
         --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 ARG DEBIAN_VERSION=11.8-slim
 FROM debian:${DEBIAN_VERSION}
 
-ENV CHANNEL=stable
 ENV ROOTLESS_UID=1000
 ENV HOME=/home/rootless
 
@@ -27,18 +26,12 @@ RUN apt-get update -y \
 RUN --mount=type=bind,source=setup-rootless-users.sh,target=/usr/bin/setup-rootless-users.sh \
     setup-rootless-users.sh
 
-COPY entrypoint.sh /usr/bin/
-RUN chmod +x /usr/bin/entrypoint.sh \
-    && chown rootless:rootless /run
+RUN --mount=type=bind,source=install-docker-rootlesskit.sh,target=/usr/bin/install-docker-rootlesskit.sh \
+    install-docker-rootlesskit.sh ${HOME}/bin
 
-# rootlesskit needs to be installed by the rootless user
+COPY entrypoint.sh /usr/bin/    
+
 USER rootless
-RUN export SKIP_IPTABLES=1 \
-    && curl -fsSL https://get.docker.com/rootless | sh \
-    && echo "Removing the '--copy-up=/run' from the dockerd-rootless.sh to allow /run/docker.sock" \
-    && sed -i 's| --copy-up=/run||g' /home/rootless/bin/dockerd-rootless.sh \
-    && /home/rootless/bin/docker -v
-
 VOLUME /var/lib/docker
 VOLUME /home/rootless/.local/share/docker
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -6,9 +6,27 @@
 
 A Docker image similar to https://hub.docker.com/\_/docker but based on Debian and Rootless Docker only. The image at https://hub.docker.com/\_/docker is based on Alpine Linux which makes using some Docker extensions like the `nvidia-container-toolkit` impossible since it relies on glibc.
 
+The core purpose this project and it's use of rootless dind is the simplicity it brings for developement and CI/CD use cases, not security. The user namespace mapping solves many quality of life issues when files are being shared and modified on the host and in the container at the same time.
+
+## Features
+
+- Rootless dockerd running on Debian
+- Use existing projects simpler because dockerd listens at both:
+    - ${XDG_RUNTIME_DIR}/docker.sock 
+    - /var/run/docker.sock 
+
 ## Configuration
 
 All configuration as described on https://hub.docker.com/\_/docker for the rootless tags are supported by this project.
+
+Rootlesskit specific variables can be supplied to override defaults:
+
+DOCKERD_ROOTLESS_ROOTLESSKIT_STATE_DIR=DIR: the rootlesskit state dir. Defaults to "$XDG_RUNTIME_DIR/dockerd-rootless".
+DOCKERD_ROOTLESS_ROOTLESSKIT_NET=(slirp4netns|vpnkit|pasta|lxc-user-nic): the rootlesskit network driver. Defaults to "slirp4netns" if slirp4netns (>= v0.4.0) is installed. Otherwise defaults to "vpnkit".
+DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=NUM: the MTU value for the rootlesskit network driver. Defaults to 65520 for slirp4netns, 1500 for other drivers.
+DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=(builtin|slirp4netns|implicit): the rootlesskit port driver. Defaults to "builtin".
+DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SANDBOX=(auto|true|false): whether to protect slirp4netns with a dedicated mount namespace. Defaults to "auto".
+DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SECCOMP=(auto|true|false): whether to protect slirp4netns with seccomp. Defaults to "auto".
 
 ## Usage example
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,10 @@ cleanup() {
 
 trap cleanup SIGTERM
 
-${HOME}/bin/dockerd-rootless.sh -H unix://${XDG_RUNTIME_DIR}/docker.sock -H unix:///run/docker.sock "$@" &
+#TODO refactor away having to sudo in the middle of this script
+sudo sysctl --system
+
+${HOME}/bin/dockerd-rootless.sh --iptables=false -H unix://${XDG_RUNTIME_DIR}/docker.sock -H unix:///run/docker.sock "$@" &
 
 ROOTLESS_PID=$!
 wait "${ROOTLESS_PID}"

--- a/install-docker-rootlesskit.sh
+++ b/install-docker-rootlesskit.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+
+set -e 
+
+INSTALL_PATH="$1"
+
+DOCKER_VERSION="26.1.2"
+DOCKER_STATIC_BINARY_URL="https://download.docker.com/linux/static/stable/$(uname -m)/docker-${DOCKER_VERSION}.tgz"
+DOCKER_ROOTLESS_EXTRAS_STATIC_BINARY_URL="https://download.docker.com/linux/static/stable/$(uname -m)/docker-rootless-extras-${DOCKER_VERSION}.tgz"
+
+# https://docs.kernel.org/networking/ip-sysctl.html
+cat << EOF > /etc/sysctl.conf
+kernel.unprivileged_userns_clone=1
+user.max_user_namespaces=28633
+net.ipv4.ping_group_range=0 4294967294
+net.ipv4.ip_unprivileged_port_start=0
+EOF
+
+mkdir -p /tmp/docker-download ${INSTALL_PATH}
+
+curl -L -o /tmp/docker-download/docker.tgz ${DOCKER_STATIC_BINARY_URL}
+curl -L -o /tmp/docker-download/rootless.tgz ${DOCKER_ROOTLESS_EXTRAS_STATIC_BINARY_URL}
+
+tar -zxf /tmp/docker-download/docker.tgz -C ${INSTALL_PATH} --strip-components=1
+tar -zxf /tmp/docker-download/rootless.tgz -C ${INSTALL_PATH} --strip-components=1
+
+${INSTALL_PATH}/docker -v
+
+chown rootless:rootless /run
+chown rootless:rootless ${INSTALL_PATH}
+
+echo "Removing the '--copy-up=/run' from the dockerd-rootless.sh to allow /run/docker.sock"
+sed -i 's| --copy-up=/run||g' ${INSTALL_PATH}/dockerd-rootless.sh
+
+rm -rf /tmp/docker-download

--- a/setup-rootless-users.sh
+++ b/setup-rootless-users.sh
@@ -8,11 +8,12 @@ usermod -aG sudo rootless
 mkdir -p ${XDG_RUNTIME_DIR}
 chown -R rootless:rootless ${XDG_RUNTIME_DIR}
 chmod a+x ${XDG_RUNTIME_DIR}
+mkdir -p ${HOME}/bin
 mkdir -p ${HOME}/.config/docker
 mkdir -p ${HOME}/.local/share/docker
-chown -R rootless:rootless ${HOME}/.config
-chown -R rootless:rootless ${HOME}/.local
+chown -R rootless:rootless ${HOME}
 
+# Reference https://docs.docker.com/engine/security/userns-remap/
 echo 'Creating subuid and subgid to enable "--userns-remap=default"'
 addgroup --system dockremap
 adduser --system --ingroup dockremap dockremap


### PR DESCRIPTION
Resolves https://github.com/enclarify/debian-dind-rootless/issues/12
Relates to https://github.com/rootless-containers/rootlesskit/issues/425

On a host system, dockerd rootless is installed with the
dockerd-rootless-setuptool.sh script. When using in dind mode the
setuptool script no longer works because rootlesskit is run in order to
test that the install was successful. This isn't possible because
rootlesskit would need to run privileged at build time.

The rootlesskit supplied install scripts are rewritten to only include
whats needed to run in dind mode.