### PR TITLE
Remap docker group in /etc/subgid for in container

### DIFF
--- a/build-scripts/setup-rootless-users.sh
+++ b/build-scripts/setup-rootless-users.sh
@@ -18,6 +18,7 @@ chown rootless:rootless /run
 echo "Creating docker group membership"
 addgroup docker --gid ${DOCKER_GID}
 usermod -aG docker rootless
+echo 'docker:231072:65536' >> /etc/subgid
 
 # Reference https://docs.docker.com/engine/security/userns-remap/
 echo 'Creating subuid and subgid to enable "--userns-remap=default"'


### PR DESCRIPTION
In order to access the host docker socket from inside a rootless container we need to remap the docker group id in the rootless namespace