### PR TITLE
Try second docker group permission fix

### DIFF
--- a/build-scripts/setup-rootless-users.sh
+++ b/build-scripts/setup-rootless-users.sh
@@ -18,7 +18,8 @@ chown rootless:rootless /run
 echo "Creating docker group membership"
 addgroup docker --gid ${DOCKER_GID}
 usermod -aG docker rootless
-echo 'docker:231072:65536' >> /etc/subgid
+# https://github.com/moby/moby/issues/40225#issuecomment-555155183
+echo 'rootless:998:998' >> /etc/subgid
 
 # Reference https://docs.docker.com/engine/security/userns-remap/
 echo 'Creating subuid and subgid to enable "--userns-remap=default"'


### PR DESCRIPTION
Trying the workaround here https://github.com/moby/moby/issues/40225#issuecomment-555155183

Seems like there can multiple mappings for primay groups