### PR TITLE
Docker group mapping finally working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM debian:${DEBIAN_VERSION}
 ENV ROOTLESS_UID=1000
 ENV DOCKER_GID=998
 ENV HOME=/home/rootless
+ENV DOCKERD_ROOTLESS_ROOTLESSKIT_DEBUG=false
 
 ENV PATH="${PATH}:${HOME}/.local/bin:${HOME}/bin"
 ENV DOCKER_HOST="unix:///run/user/${ROOTLESS_UID}/docker.sock"

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ All configuration as described on https://hub.docker.com/\_/docker for the rootl
 
 Rootlesskit specific variables can be supplied to override defaults:
 
-DOCKERD_ROOTLESS_ROOTLESSKIT_STATE_DIR=DIR: the rootlesskit state dir. Defaults to "$XDG_RUNTIME_DIR/dockerd-rootless".
-DOCKERD_ROOTLESS_ROOTLESSKIT_NET=(slirp4netns|vpnkit|pasta|lxc-user-nic): the rootlesskit network driver. Defaults to "slirp4netns" if slirp4netns (>= v0.4.0) is installed. Otherwise defaults to "vpnkit".
-DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=NUM: the MTU value for the rootlesskit network driver. Defaults to 65520 for slirp4netns, 1500 for other drivers.
-DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=(builtin|slirp4netns|implicit): the rootlesskit port driver. Defaults to "builtin".
-DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SANDBOX=(auto|true|false): whether to protect slirp4netns with a dedicated mount namespace. Defaults to "auto".
-DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SECCOMP=(auto|true|false): whether to protect slirp4netns with seccomp. Defaults to "auto".
+- DOCKERD_ROOTLESS_ROOTLESSKIT_STATE_DIR=DIR: the rootlesskit state dir. Defaults to "$XDG_RUNTIME_DIR/dockerd-rootless".
+- DOCKERD_ROOTLESS_ROOTLESSKIT_NET=(slirp4netns|vpnkit|pasta|lxc-user-nic): the rootlesskit network driver. Defaults to "slirp4netns" if slirp4netns (>= v0.4.0) is installed. Otherwise defaults to "vpnkit".
+- DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=NUM: the MTU value for the rootlesskit network driver. Defaults to 65520 for slirp4netns, 1500 for other drivers.
+- DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=(builtin|slirp4netns|implicit): the rootlesskit port driver. Defaults to "builtin".
+- DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SANDBOX=(auto|true|false): whether to protect slirp4netns with a dedicated mount namespace. Defaults to "auto".
+- DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SECCOMP=(auto|true|false): whether to protect slirp4netns with seccomp. Defaults to "auto".
 
 ## Usage example
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ All configuration as described on https://hub.docker.com/\_/docker for the rootl
 
 Rootlesskit specific variables can be supplied to override defaults:
 
+- DOCKERD_ROOTLESS_ROOTLESSKIT_DEBUG=(true|false): Toggle rootlesskit debugging. Defaults to "false".
 - DOCKERD_ROOTLESS_ROOTLESSKIT_STATE_DIR=DIR: the rootlesskit state dir. Defaults to "$XDG_RUNTIME_DIR/dockerd-rootless".
 - DOCKERD_ROOTLESS_ROOTLESSKIT_NET=(slirp4netns|vpnkit|pasta|lxc-user-nic): the rootlesskit network driver. Defaults to "slirp4netns" if slirp4netns (>= v0.4.0) is installed. Otherwise defaults to "vpnkit".
 - DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=NUM: the MTU value for the rootlesskit network driver. Defaults to 65520 for slirp4netns, 1500 for other drivers.

--- a/build-scripts/install-docker-rootlesskit.sh
+++ b/build-scripts/install-docker-rootlesskit.sh
@@ -19,8 +19,8 @@ EOF
 
 mkdir -p /tmp/docker-download ${INSTALL_PATH}
 
-curl -L -o /tmp/docker-download/docker.tgz ${DOCKER_STATIC_BINARY_URL}
-curl -L -o /tmp/docker-download/rootless.tgz ${DOCKER_ROOTLESS_EXTRAS_STATIC_BINARY_URL}
+curl -sSL -o /tmp/docker-download/docker.tgz ${DOCKER_STATIC_BINARY_URL}
+curl -sSL -o /tmp/docker-download/rootless.tgz ${DOCKER_ROOTLESS_EXTRAS_STATIC_BINARY_URL}
 
 tar -zxf /tmp/docker-download/docker.tgz -C ${INSTALL_PATH} --strip-components=1
 tar -zxf /tmp/docker-download/rootless.tgz -C ${INSTALL_PATH} --strip-components=1

--- a/build-scripts/setup-rootless-users.sh
+++ b/build-scripts/setup-rootless-users.sh
@@ -2,6 +2,13 @@
 
 set -e
 
+# allows all system groups to be mapping into 
+# rootless user namespace. This allows supplimental groups
+# like 'docker' on the host to be properly mapped into 
+# rootless containers
+# TODO scope this smaller in the future
+echo "rootless:1:999" >> /etc/subgid
+
 echo "Adding rootless user"
 adduser --disabled-password --gecos "" --uid ${ROOTLESS_UID} rootless
 usermod -aG sudo rootless
@@ -18,8 +25,6 @@ chown rootless:rootless /run
 echo "Creating docker group membership"
 addgroup docker --gid ${DOCKER_GID}
 usermod -aG docker rootless
-# https://github.com/moby/moby/issues/40225#issuecomment-555155183
-echo 'rootless:998:998' >> /etc/subgid
 
 echo "Setting up passwordless sudo"
 echo "%sudo   ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers

--- a/build-scripts/setup-rootless-users.sh
+++ b/build-scripts/setup-rootless-users.sh
@@ -21,13 +21,6 @@ usermod -aG docker rootless
 # https://github.com/moby/moby/issues/40225#issuecomment-555155183
 echo 'rootless:998:998' >> /etc/subgid
 
-# Reference https://docs.docker.com/engine/security/userns-remap/
-echo 'Creating subuid and subgid to enable "--userns-remap=default"'
-addgroup --system dockremap
-adduser --system --ingroup dockremap dockremap
-echo 'dockremap:165536:65536' >> /etc/subuid
-echo 'dockremap:165536:65536' >> /etc/subgid
-
 echo "Setting up passwordless sudo"
 echo "%sudo   ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
 echo "Defaults !env_reset" >> /etc/sudoers

--- a/runtime-scripts/set-dynamic-attributes.sh
+++ b/runtime-scripts/set-dynamic-attributes.sh
@@ -12,5 +12,10 @@ sudo chown rootless:rootless /run
 echo "Updating docker gid"
 sudo groupmod --gid ${DOCKER_GID} docker
 
+if [ "${DOCKERD_ROOTLESS_ROOTLESSKIT_DEBUG}" = true ]; then
+    echo "Turning on rootlesskit debugging"
+    sed -i 's|exec $rootlesskit|exec $rootlesskit --debug|' ${HOME}/bin/dockerd-rootless.sh
+fi
+
 # apply kernel parameters
 sudo sysctl --system


### PR DESCRIPTION
[fix env var documentation formatting](https://github.com/enclarify/debian-dind-rootless/pull/17/commits/54548e2e00f9abdd7aa19d489f83bb5ad56a76fb)

[silently use curl](https://github.com/enclarify/debian-dind-rootless/pull/17/commits/c761d866cc06f924b92fadf2ad73da10ae35628b)

[Toggle rootlesskit debug flag with env var](https://github.com/enclarify/debian-dind-rootless/pull/17/commits/9717375416caa8fcc604bf22075fb4238d22ab4f)

[Remove dockremap, not used with rootlesskit](https://github.com/enclarify/debian-dind-rootless/pull/17/commits/b4efc6623b9d68abd7f9c3ae5159a938f16b8be8) 
Setting up dockremap is only useful when directly leveraging the user
namespace remapping of dockerd. Rootlesskit is managing the mapping by
setting up the container user, 'rootless' in this case.

[Map all system groups into rootless user namespace](https://github.com/enclarify/debian-dind-rootless/pull/17/commits/9582bbb90c7237e02e0319d10b22518dcba382ee) 
Instead of trying to specifically map the docker group we map the entire
space the system groups. The way subgid mapping works is that it
sequential maps a range of groups on the host into the user namespace.
For example if `rootless:998:1` is the first entry in subgid then the
host group 998 gets mapped to user namespace group 1. Mapping all the
system groups ensures the order stays the same as the host and any
system group docker is using it will get mapped