### PR TITLE
Add iptables back to base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update -y \
         curl \
         ca-certificates \
         iproute2 \
+        iptables \
         jq \
         sudo \
         uidmap \


### PR DESCRIPTION
In the process of working through the core dependencies of rootlesskit it seems iptables is required even though a previous configuration attempted to turn it off thinking it wasn't required. Without iptables network access is blocked