### PR TITLE
Add slirp4netns dependency back, fixes networking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update -y \
         ca-certificates \
         iproute2 \
         iptables \
+        slirp4netns \
         jq \
         sudo \
         uidmap \


### PR DESCRIPTION
In previous testing it seemed like it was iptables that fixed the networking but slirp4netns is also required to be installed