### PR TITLE
Move rootlesskit install location to /usr/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update -y \
 
 RUN --mount=type=bind,source=build-scripts,target=/opt/build-scripts \
     /opt/build-scripts/setup-rootless-users.sh \
-    && /opt/build-scripts/install-docker-rootlesskit.sh ${HOME}/bin
+    && /opt/build-scripts/install-docker-rootlesskit.sh /usr/bin
 
 COPY runtime-scripts/* /usr/bin/
 

--- a/build-scripts/install-docker-rootlesskit.sh
+++ b/build-scripts/install-docker-rootlesskit.sh
@@ -28,7 +28,6 @@ tar -zxf /tmp/docker-download/rootless.tgz -C ${INSTALL_PATH} --strip-components
 ${INSTALL_PATH}/docker -v
 
 chown rootless:rootless /run
-chown rootless:rootless ${INSTALL_PATH}
 
 echo "Removing the '--copy-up=/run' from the dockerd-rootless.sh to allow /run/docker.sock"
 sed -i 's| --copy-up=/run||g' ${INSTALL_PATH}/dockerd-rootless.sh


### PR DESCRIPTION
Turns out when running on Ubuntu 24.04 with AppArmor you need to install rootlesskit in /usr/bin or you will get the error "failed to start the child: fork/exec /proc/self/exe: operation not permitted". This is explained in the following link as well:

https://rootlesscontaine.rs/getting-started/common/apparmor/