### PR TITLE
Make rootlesskit install location not configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update -y \
 
 RUN --mount=type=bind,source=build-scripts,target=/opt/build-scripts \
     /opt/build-scripts/setup-rootless-users.sh \
-    && /opt/build-scripts/install-docker-rootlesskit.sh /usr/bin
+    && /opt/build-scripts/install-docker-rootlesskit.sh
 
 COPY runtime-scripts/* /usr/bin/
 

--- a/build-scripts/install-docker-rootlesskit.sh
+++ b/build-scripts/install-docker-rootlesskit.sh
@@ -3,8 +3,6 @@
 
 set -e 
 
-INSTALL_PATH="$1"
-
 DOCKER_VERSION="26.1.2"
 DOCKER_STATIC_BINARY_URL="https://download.docker.com/linux/static/stable/$(uname -m)/docker-${DOCKER_VERSION}.tgz"
 DOCKER_ROOTLESS_EXTRAS_STATIC_BINARY_URL="https://download.docker.com/linux/static/stable/$(uname -m)/docker-rootless-extras-${DOCKER_VERSION}.tgz"
@@ -17,19 +15,21 @@ net.ipv4.ping_group_range=0 4294967294
 net.ipv4.ip_unprivileged_port_start=0
 EOF
 
-mkdir -p /tmp/docker-download ${INSTALL_PATH}
+mkdir -p /tmp/docker-download
 
 curl -sSL -o /tmp/docker-download/docker.tgz ${DOCKER_STATIC_BINARY_URL}
 curl -sSL -o /tmp/docker-download/rootless.tgz ${DOCKER_ROOTLESS_EXTRAS_STATIC_BINARY_URL}
 
-tar -zxf /tmp/docker-download/docker.tgz -C ${INSTALL_PATH} --strip-components=1
-tar -zxf /tmp/docker-download/rootless.tgz -C ${INSTALL_PATH} --strip-components=1
+tar -zxf /tmp/docker-download/docker.tgz -C /usr/bin --strip-components=1
+tar -zxf /tmp/docker-download/rootless.tgz -C /usr/bin --strip-components=1
 
-${INSTALL_PATH}/docker -v
+/usr/bin/docker -v
 
 chown rootless:rootless /run
+# Owned by rootless so we can turn on debugging at runtime
+chown rootless:rootless /usr/bin/dockerd-rootless.sh
 
 echo "Removing the '--copy-up=/run' from the dockerd-rootless.sh to allow /run/docker.sock"
-sed -i 's| --copy-up=/run||g' ${INSTALL_PATH}/dockerd-rootless.sh
+sed -i 's| --copy-up=/run||g' /usr/bin/dockerd-rootless.sh
 
 rm -rf /tmp/docker-download

--- a/runtime-scripts/set-dynamic-attributes.sh
+++ b/runtime-scripts/set-dynamic-attributes.sh
@@ -14,7 +14,7 @@ sudo groupmod --gid ${DOCKER_GID} docker
 
 if [ "${DOCKERD_ROOTLESS_ROOTLESSKIT_DEBUG}" = true ]; then
     echo "Turning on rootlesskit debugging"
-    sed -i 's|exec $rootlesskit|exec $rootlesskit --debug|' ${HOME}/bin/dockerd-rootless.sh
+    sed -i 's|exec $rootlesskit|exec $rootlesskit --debug|' /usr/bin/dockerd-rootless.sh
 fi
 
 # apply kernel parameters

--- a/runtime-scripts/start-rootless.sh
+++ b/runtime-scripts/start-rootless.sh
@@ -39,7 +39,7 @@ cleanup() {
 
 trap cleanup SIGTERM
 
-${HOME}/bin/dockerd-rootless.sh -H unix://${XDG_RUNTIME_DIR}/docker.sock -H unix:///run/docker.sock "$@" &
+/usr/bin/dockerd-rootless.sh -H unix://${XDG_RUNTIME_DIR}/docker.sock -H unix:///run/docker.sock "$@" &
 
 ROOTLESS_PID=$!
 wait "${ROOTLESS_PID}"


### PR DESCRIPTION
Last PR attempted to change the install location by passing the option to the install script but there were other places that assumed the location was in /home. This changes the approach to hardcode the install location to be /usr/bin